### PR TITLE
Implement DIE

### DIFF
--- a/IRCNumericReplies.hpp
+++ b/IRCNumericReplies.hpp
@@ -95,4 +95,7 @@
 /*   handleNAMES    */
 # define RPL_ENDOFNAMES(server, target, channel) (IRC_RPL("366", server, target) + " " +channel + " :End of NAMES list\r\n")
 
+/*   handleDIE */
+# define ERR_NOPRIVILEGES(server, target) (IRC_RPL("481", server, target) + " :Permission Denied- You're not an IRC operator\r\n")
+
 #endif

--- a/IRCServer.hpp
+++ b/IRCServer.hpp
@@ -81,6 +81,7 @@ class IRCServer : virtual public TCPServer<IRCUser>
 		void	S_handleJOIN(IRCUser &user, const IRCMessage &msg);
 		void	S_handlePRIVMSG(IRCUser &user, const IRCMessage &msg);
 		void	S_handleNOTICE(IRCUser &user, const IRCMessage &msg);
+		void	S_handleDIE(IRCUser &user, const IRCMessage &msg);
 
 		/*	Channel Commands	*/
 		void	C_handleWHO(IRCUser &user, const IRCMessage &msg);
@@ -111,6 +112,7 @@ class IRCServer : virtual public TCPServer<IRCUser>
 		std::string									conn_pass;
 		std::string									servername;
 		std::string									time_created;
+		bool										shutdown;
 };
 
 #endif

--- a/IRCServer_cmd.cpp
+++ b/IRCServer_cmd.cpp
@@ -515,3 +515,18 @@ void	IRCServer::S_handleNOTICE(IRCUser &user, const IRCMessage &msg)
 		}
 	}
 }
+
+void	IRCServer::S_handleDIE(IRCUser &user, const IRCMessage &msg)
+{
+	(void)msg;
+	std::string reply;
+	
+	if (users_map.find(user.getNickname()) == users_map.end()
+		|| !clients[users_map[user.getNickname()]].isOperator())
+	{
+		reply = ERR_NOPRIVILEGES(servername, user.getNickname());
+		user.queueSend(reply.c_str(), reply.size());
+		return ;
+	}
+	shutdown = true;
+}


### PR DESCRIPTION
Can't force clients to gracefully terminate connctions, so the listening port stays occupied for some time after the server is terminated.